### PR TITLE
Fix payments format

### DIFF
--- a/bb
+++ b/bb
@@ -586,7 +586,7 @@ bb_payments() {
 	echo Confirmation Number,Date,Amount,Account,Payment Method,Payer
 	quikpay_request $quikpay_history_path |\
 		sed '/<td/,/\w/!d; /<td/d; s/^\s*//; s/\s*$//; /<img/d; /^$/d' |\
-		sed '$!N;N;N;N;N; s/\n/,/g'
+		sed '$!N;N;N;N;N;N; s/\n/,/g'
 }
 
 usage_bill() {


### PR DESCRIPTION
There's 6 fields, but the sed command only accounted for 5 of them, so the line break was inserted in the wrong place.
