### PR TITLE
Fix find -perm syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# netrc
+.netrc

--- a/bb
+++ b/bb
@@ -51,7 +51,7 @@ bb_request() {
 
 # check if a file is accessible to other users
 insecure_file() {
-	[[ -n `find $1 -perm 066` ]]
+	[[ -n `find $1 -perm +066 2>&-; find $1 -perm /066 2>&-` ]]
 }
 
 # get saved login info from ~/.netrc

--- a/bb
+++ b/bb
@@ -51,7 +51,7 @@ bb_request() {
 
 # check if a file is accessible to other users
 insecure_file() {
-	[[ -n `find $1 -perm /066` ]]
+	[[ -n `find $1 -perm \066` ]]
 }
 
 # get saved login info from ~/.netrc

--- a/bb
+++ b/bb
@@ -51,7 +51,7 @@ bb_request() {
 
 # check if a file is accessible to other users
 insecure_file() {
-	[[ -n `find $1 -perm \066` ]]
+	[[ -n `find $1 -perm 066` ]]
 }
 
 # get saved login info from ~/.netrc


### PR DESCRIPTION
`find $1 -perm /066` gives an error with find on OSX. Changed to `find $1 -perm 066`.