### PR TITLE
Warn users if curl is not installed, and exit

### DIFF
--- a/bb
+++ b/bb
@@ -47,7 +47,7 @@ bb_request() {
 	fi
 	shift
 	check_cookies
-    check_curl
+	check_curl
 	curl -s -b "$cookie_jar" -c "$cookie_jar" "$url" $@ 2>&-
 }
 
@@ -74,19 +74,19 @@ parse_netrc() {
 
 # Check to see if curl is installed for current user
 check_curl() {
-    # check if curl already verified
-    if [[ -z $curl_installed ]]; then
+	# check if curl already verified
+	if [[ -z $curl_installed ]]; then
 
-        # if curl installed, set 1
-        which curl && curl_installed=1
+		# if curl installed, set 1
+		which curl && curl_installed=1
 
-        # if curl_installed is still unset, not installed, exit
-        if [[ -z $curl_installed ]]; then
-            echo "'curl' is not installed, install curl before running bb." >&2
-            echo "info: http://curl.haxx.se/docs/manpage.html" >&2
-            exit 1
-        fi
-    fi
+		# if curl_installed is still unset, not installed, exit
+		if [[ -z $curl_installed ]]; then
+			echo "'curl' is not installed, install curl before running bb." >&2
+			echo "info: http://curl.haxx.se/docs/manpage.html" >&2
+			exit 1
+		fi
+	fi
 }
 
 # Check the cookie file and create it if necessary
@@ -557,8 +557,8 @@ bb_balance() {
 	uros=${part2%%,*}
 
 	if [[ $print_both ]]; then
-        printf "decl:\t\$ $declining\n"
-        printf "uros:\t\$ $uros\n"
+		printf "decl:\t\$ $declining\n"
+		printf "uros:\t\$ $uros\n"
 	elif [[ $print_declining ]]; then echo $declining
 	elif [[ $print_uros ]]; then echo $uros
 	fi

--- a/bb
+++ b/bb
@@ -33,6 +33,7 @@ authenticated=
 
 verbose_mode=
 cookie_jar_checked=
+curl_installed=
 
 # exit codes
 EX_USAGE=64
@@ -46,6 +47,7 @@ bb_request() {
 	fi
 	shift
 	check_cookies
+    check_curl
 	curl -s -b "$cookie_jar" -c "$cookie_jar" "$url" $@ 2>&-
 }
 
@@ -68,6 +70,17 @@ parse_netrc() {
 	cred=`sed -n "/machine $bb_server/,/machine /p" $netrc`
 	user_id=`sed -n 's/.*login \([^ ]*\).*/\1/p' <<< $cred`
 	password=`sed -n 's/.*password \([^ ]*\).*/\1/p' <<< $cred`
+}
+
+# Check to see if curl is installed for current user
+check_curl() {
+    if [[-z curl_installed]]; then
+        which curl && curl_installed=1
+        if[[ -z curl_installed ]]; then
+            echo "'curl' is not installed, install curl" >&2
+            exit 1
+        fi
+    fi
 }
 
 # Check the cookie file and create it if necessary

--- a/bb
+++ b/bb
@@ -74,10 +74,16 @@ parse_netrc() {
 
 # Check to see if curl is installed for current user
 check_curl() {
-    if [[-z curl_installed]]; then
+    # check if curl already verified
+    if [[ -z $curl_installed ]]; then
+
+        # if curl installed, set 1
         which curl && curl_installed=1
-        if[[ -z curl_installed ]]; then
-            echo "'curl' is not installed, install curl" >&2
+
+        # if curl_installed is still unset, not installed, exit
+        if [[ -z $curl_installed ]]; then
+            echo "'curl' is not installed, install curl before running bb." >&2
+            echo "info: http://curl.haxx.se/docs/manpage.html" >&2
             exit 1
         fi
     fi

--- a/bb
+++ b/bb
@@ -37,9 +37,6 @@ cookie_jar_checked=
 # exit codes
 EX_USAGE=64
 
-# check if user has curl
-check_curl
-
 bb_request() {
 	# Allow path or full url
 	if [[ ${1:0:1} == "/" ]]; then
@@ -830,6 +827,10 @@ if [[ $# -lt 1 ]]
 then
 	usage_main
 fi
+
+# check if user has curl
+
+check_curl
 
 for arg; do
 	if [[ $arg == '-v' ]]; then

--- a/bb
+++ b/bb
@@ -33,10 +33,12 @@ authenticated=
 
 verbose_mode=
 cookie_jar_checked=
-curl_installed=
 
 # exit codes
 EX_USAGE=64
+
+# check if user has curl
+check_curl
 
 bb_request() {
 	# Allow path or full url
@@ -47,7 +49,6 @@ bb_request() {
 	fi
 	shift
 	check_cookies
-	check_curl
 	curl -s -b "$cookie_jar" -c "$cookie_jar" "$url" $@ 2>&-
 }
 
@@ -74,19 +75,11 @@ parse_netrc() {
 
 # Check to see if curl is installed for current user
 check_curl() {
-	# check if curl already verified
-	if [[ -z $curl_installed ]]; then
-
-		# if curl installed, set 1
-		which curl && curl_installed=1
-
-		# if curl_installed is still unset, not installed, exit
-		if [[ -z $curl_installed ]]; then
-			echo "'curl' is not installed, install curl before running bb." >&2
-			echo "info: http://curl.haxx.se/docs/manpage.html" >&2
-			exit 1
-		fi
-	fi
+	type curl >/dev/null 2>&1 || {
+		echo "'curl' is not installed, install curl before running bb." >&2
+		echo "info: http://curl.haxx.se/docs/manpage.html" >&2
+		exit 1
+	}
 }
 
 # Check the cookie file and create it if necessary


### PR DESCRIPTION
Potentially take care of #4. Haven't tested with a machine that doesn't have curl however...