### PR TITLE
Add command for paying tuition

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ Get your history of tuition payments (in CSV format):
 
     $ bb history
 
+Making tuition payments
+-----------------------
+
+    bb pay [-m <method>] [<amount>]
+
+Example:
+
+    $ bb pay -m coop
+    Found Genesee Coop FCU (CHECKING XXXX)
+    Payment amount: 100 <---- user input
+
+    ...
+
+    Confirm this payment? [y/n] n
+    Payment cancelled
+
 Verbose mode
 ----------
 

--- a/bb
+++ b/bb
@@ -26,6 +26,7 @@ quikpay_current_statement_path='/rochester/qp/ebill/currentStatementDispatcher.d
 quikpay_payment_path='/rochester/qp/epay/index.do'
 quikpay_payment_confirm_path='/rochester/qp/epay/submitAmountMethod.do'
 quikpay_payment_submit_path='/rochester/qp/epay/submitCheckECheckConfirmation.do'
+quikpay_payment_process_path='/rochester/qp/epay/processPayment.do'
 cookie_jar=~/.bbsession
 
 # login info will be filled from ~/.netrc or by prompting the user
@@ -767,6 +768,15 @@ bb_pay() {
 			s/.*//
 			h
 		}
+	}
+	# print disclaimer
+	/epay_ECheckConfirmation_eCheckDisclaimer/{
+		N
+		s/[[:blank:]]*<[^>]*>[[:blank:]]*/ /g
+		s/  */ /g
+		s/^ *\| *$//
+		s/\([\n\r]*\) */\1/
+		p
 	}'
 
 	echo
@@ -782,8 +792,11 @@ bb_pay() {
 	batch_id=$(quikpay_request $quikpay_payment_submit_path -LF "$special"\
 		| sed -n 's/.* name="batchId" value="\([^"]*\)">.*/\1/p')
 
-	echo payment not yet submitted
-	echo batch ID: $batch_id
+	echo Submitting payment ID $batch_id...
+	quikpay_request $quikpay_payment_process_path -L \
+		-F "$special"\
+		-F "batchID=$batch_id" \
+		-F "dummy="
 }
 
 

--- a/bb
+++ b/bb
@@ -193,6 +193,7 @@ bb_help() {
 	echo '    balance    Get your declining/Uros balance'
 	echo '    bill       Get your current tuition bill'
 	echo '    payments   Get your history of tuition payments'
+	echo '    pay        Make tuition payment'
 	echo 'Global options:'
 	echo '    -v         Increase verbosity'
 }
@@ -710,7 +711,8 @@ parse_quikpay_error() {
 	sed -n '
 	/<h1 class="pageTitle">/{
 		n
-		s///
+		s/
+//
 		s/^[ 	]*//p
 	}
 	/etcErrorMessage/{
@@ -718,7 +720,8 @@ parse_quikpay_error() {
 		N
 		/<\/p>/!ba
 		# extract error message
-		y/\n	/   /
+		y/\n
+	/   /
 		s/.*<p[^>]*> *//
 		s/ *<\/p>.*//p
 		q
@@ -783,7 +786,8 @@ bb_pay() {
 		N
 		/ <\/div>/!ba
 		s/ *<[^>]*>//g
-		s///g
+		s/
+//g
 		s/\n//g
 		s/&nbsp;/ /g
 		p
@@ -801,8 +805,10 @@ bb_pay() {
 		/<\/td>/!blabel
 		s/<[^>]*>//g
 		y/\n/ /
-		s/^[ ]*//
-		s/[ ]*$//
+		s/^[
+ ]*//
+		s/[
+ ]*$//
 		h
 		bz
 	:value
@@ -812,7 +818,8 @@ bb_pay() {
 		# strip tags
 		#/0311/l
 		s/<[^>]*>//g
-		s///g
+		s/
+//g
 		y/\n/ /
 		s/  */ /g
 		s/  *$//
@@ -830,9 +837,11 @@ bb_pay() {
 		N
 		s/<[^>]*>/ /g
 		s/  */ /g
-		s/^ //
+		s/^ 
+//
 		s/\(\n\) /\1/
-		s/[ ]*$//
+		s/[
+ ]*$//
 		G
 		p
 	}'

--- a/bb
+++ b/bb
@@ -707,12 +707,20 @@ parse_payment_profiles() {
 }
 
 parse_quikpay_error() {
-	sed -n '/etcErrorMessage/{
+	sed -n '
+	/<h1 class="pageTitle">/{
+		n
+		s///
+		s/^[ 	]*//p
+	}
+	/etcErrorMessage/{
 		:a
 		N
 		/<\/p>/!ba
 		# extract error message
-		s/.*<p>\([^<]*\)<\/p>.*/\1/p
+		y/\n	/   /
+		s/.*<p[^>]*> *//
+		s/ *<\/p>.*//p
 		q
 	}'
 }

--- a/bb
+++ b/bb
@@ -712,8 +712,7 @@ parse_quikpay_error() {
 	sed -n '
 	/<h1 class="pageTitle">/{
 		n
-		s/
-//
+		s/'$'\r''//
 		s/^[ 	]*//p
 	}
 	/etcErrorMessage/{
@@ -721,8 +720,7 @@ parse_quikpay_error() {
 		N
 		/<\/p>/!ba
 		# extract error message
-		y/\n
-	/   /
+		y/\n'$'\r\t''/   /
 		s/.*<p[^>]*> *//
 		s/ *<\/p>.*//p
 		q
@@ -787,8 +785,7 @@ bb_pay() {
 		N
 		/ <\/div>/!ba
 		s/ *<[^>]*>//g
-		s/
-//g
+		s/'$'\r''//g
 		s/\n//g
 		s/&nbsp;/ /g
 		p
@@ -806,10 +803,8 @@ bb_pay() {
 		/<\/td>/!blabel
 		s/<[^>]*>//g
 		y/\n/ /
-		s/^[
- ]*//
-		s/[
- ]*$//
+		s/^['$'\r'' ]*//
+		s/['$'\r'' ]*$//
 		h
 		bz
 	:value
@@ -819,8 +814,7 @@ bb_pay() {
 		# strip tags
 		#/0311/l
 		s/<[^>]*>//g
-		s/
-//g
+		s/'$'\r''//g
 		y/\n/ /
 		s/  */ /g
 		s/  *$//
@@ -838,11 +832,9 @@ bb_pay() {
 		N
 		s/<[^>]*>/ /g
 		s/  */ /g
-		s/^ 
-//
+		s/^ '$'\r''/
 		s/\(\n\) /\1/
-		s/[
- ]*$//
+		s/['$'\r'' ]*$//
 		G
 		p
 	}'

--- a/bb
+++ b/bb
@@ -767,9 +767,9 @@ bb_pay() {
 
 	# prepare for confirmation
 	quikpay_request $quikpay_payment_confirm_path -L \
-		-F "paymentAmount[0].amount=$amount"\
-		-F "method=$method"\
-		-F "$special"\
+		-d "paymentAmount[0].amount=$amount"\
+		-d "method=${method// /%20}"\
+		-d "$special"\
 		| sed -n '
 	# begin with blank line
 	1{

--- a/bb
+++ b/bb
@@ -769,31 +769,48 @@ bb_pay() {
 		p
 	}
 	# get labels and values
-	/<td class="\(summary\|io\)\(Label\|Value\)/{
-		:a
+	/<td class="summaryLabel"/blabel
+	/<td class="ioLabel"/blabel
+	/<td class="summaryValue"/bvalue
+	/<td class="ioValue"/bvalue
+	bz
+	:label
 		N
-		/<\/td>/!ba
+		/<\/td>/!blabel
+		s/<[^>]*>//g
+		y/\n/ /
+		s/^[ ]*//
+		s/[ ]*$//
+		h
+		bz
+	:value
+		N
+		/<\/td>/!bvalue
 		# add space
-		s/[\n\r[:blank:]]*<span class="attentionText">[\n\r[:blank:]]*/ /
 		# strip tags
-		s/[\n\r[:blank:]]*<[^>]*>[\n\r[:blank:]]*//g
+		#/0311/l
+		s/<[^>]*>//g
+		s///g
+		y/\n/ /
+		s/  */ /g
+		s/  *$//
+		s/^  *//
 		# print in form "label: value"
 		x
-		/./{
-			G
-			s/[\n\r]/ /g
-			p
-			s/.*//
-			h
-		}
-	}
+		G
+		s/\n\n*/ /g
+		p
+		s/.*//
+		h
+	:z
 	# print disclaimer
 	/epay_ECheckConfirmation_eCheckDisclaimer/{
 		N
-		s/[[:blank:]]*<[^>]*>[[:blank:]]*/ /g
+		s/<[^>]*>/ /g
 		s/  */ /g
-		s/^ *\| *$//
-		s/\([\n\r]*\) */\1/
+		s/^ //
+		s/\(\n\) /\1/
+		s/[ ]*$//
 		G
 		p
 	}'

--- a/bb
+++ b/bb
@@ -683,7 +683,7 @@ bb_payments() {
 }
 
 usage_pay() {
-	echo "Usage: bb pay [-vf] [-m <payment_method>] [<amount>]" >&2
+	echo "Usage: bb pay [-v] [-m <payment_method>] [<amount>]" >&2
 	exit 1
 }
 

--- a/bb
+++ b/bb
@@ -698,7 +698,8 @@ parse_payment_profiles() {
 	/<option/!q
 	h
 	# extract and print the first item
-	s/<option[^>]* value="\([^"]*\)"[^>]*>[^(]*(\([^<]*\))[^<]*<\/option>.*/\1 (\2)/p
+	s/<option[^>]* value="\([^"]*\)"[^>]*>[^(]*(\([^<]*\))[^<]*<\/option>.*/\1 (\2)/
+	p
 	g
 	# remove the first item
 	s/<option[^>]*>[^<]*<\/option>//

--- a/bb
+++ b/bb
@@ -757,7 +757,7 @@ bb_pay() {
 	rm $temp
 
 	pick_item 'Choose a payment profile' "$methods" "$method" || exit
-	method=${ITEM%(*}
+	method=${ITEM% (*}
 
 	# prompt for payment amount if not given as argument
 	while [[ -z "$amount" ]]
@@ -776,6 +776,20 @@ bb_pay() {
 		s/.*//
 		p
 	}
+
+	# error?
+	/template_include_Content_error/{
+		:a
+		N
+		/ <\/div>/!ba
+		s/ *<[^>]*>//g
+		s///g
+		s/\n//g
+		s/&nbsp;/ /g
+		p
+		q
+	}
+
 	# get labels and values
 	/<td class="summaryLabel"/blabel
 	/<td class="ioLabel"/blabel


### PR DESCRIPTION
:warning: :money_with_wings: 

This adds a `pay` command for making tuition payments. Currently it works for me ~~with my payment profile that is one word, but doesn't work if the payment profile is more than one word. I am still looking into this~~. Be careful with testing that you are sure you want to make a payment (or otherwise don't let execution get to `quikpay_payment_process_path` 

I also added an abstract `pick_item` function for use with picking payment profiles, which could be used to replace parts of `get_course` and `get_assignment` as they implement mostly the same logic.